### PR TITLE
Implement /new epoch reset

### DIFF
--- a/streams/services/epoch.py
+++ b/streams/services/epoch.py
@@ -7,6 +7,16 @@ class EpochManager:
     def __init__(self):
         self.active = {}
 
+    def close_epoch(self, stream_id):
+        """Force-close the active epoch for ``stream_id``.
+
+        This is used when a client sends the ``/new`` command. By removing the
+        current epoch from ``self.active`` we ensure that the next message for
+        the stream will start a fresh epoch when ``handle()`` is invoked.
+        """
+
+        self.active.pop(stream_id, None)
+
     async def handle(self, msg):
         # TODO: barrier detection & upsert to qdrant
         pass

--- a/streams/services/router.py
+++ b/streams/services/router.py
@@ -3,6 +3,8 @@ from typing import Set
 
 from fastapi import WebSocket
 
+from streams.services.epoch import epoch_manager
+
 
 class StreamRouter:
     def __init__(self, stream_id):
@@ -19,7 +21,7 @@ class StreamRouter:
         )
 
     def flag_manual_barrier(self):
-        pass
+        epoch_manager.close_epoch(self.stream_id)
 
     async def disconnect(self, ws: WebSocket):
         self._clients.discard(ws)


### PR DESCRIPTION
## Summary
- add EpochManager.close_epoch() helper
- close epoch when `/new` is received

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859aba8f68c8331809160aef44b5eae