### PR TITLE
Add message pagination API

### DIFF
--- a/streams/api/rest.py
+++ b/streams/api/rest.py
@@ -1,4 +1,8 @@
-from fastapi import APIRouter
+from uuid import UUID
+
+from fastapi import APIRouter, Query
+
+from streams.storage import postgres
 
 router = APIRouter(prefix="/api")
 
@@ -13,3 +17,12 @@ async def list_providers():
 async def create_stream(name: str):
     # TODO: insert row + return stream info
     return {"id": "stub", "name": name}
+
+
+@router.get("/streams/{stream_id}/messages")
+async def list_messages(
+    stream_id: UUID, page: int = Query(0, ge=0), limit: int = Query(20, ge=1, le=100)
+):
+    offset = page * limit
+    messages = await postgres.get_messages(stream_id, offset=offset, limit=limit)
+    return messages

--- a/streams/storage/postgres.py
+++ b/streams/storage/postgres.py
@@ -1,8 +1,11 @@
 import asyncpg
+from collections import defaultdict
+from uuid import uuid4
 
 from streams.config import settings
 
 _pool = None
+_messages_by_stream = defaultdict(list)
 
 
 async def init_pool(dsn: str):
@@ -11,11 +14,17 @@ async def init_pool(dsn: str):
 
 
 async def save_message(stream_id, author, content):
-    # Simplified insert; returns dict for demo
-    return {
-        "id": "stub",
-        "stream_id": stream_id,
+    msg = {
+        "id": str(uuid4()),
+        "stream_id": str(stream_id),
         "author": author,
         "content": content,
         "epoch_id": None,
     }
+    _messages_by_stream[str(stream_id)].append(msg)
+    return msg
+
+
+async def get_messages(stream_id, offset: int = 0, limit: int = 20):
+    msgs = _messages_by_stream.get(str(stream_id), [])
+    return msgs[offset : offset + limit]

--- a/streams/templates/chat.html
+++ b/streams/templates/chat.html
@@ -31,6 +31,33 @@
     const form = document.getElementById("chat-form")
     const input = document.getElementById("chat-input")
 
+    let page = 0
+    const pageSize = 20
+
+    async function loadMessages() {
+        const res = await fetch(`/api/streams/${streamId}/messages?page=${page}&limit=${pageSize}`)
+        if (res.ok) {
+            const msgs = await res.json()
+            msgs.forEach((m) => {
+                const div = document.createElement("div")
+                div.textContent = `${m.author}: ${m.content}`
+                log.appendChild(div)
+            })
+            if (msgs.length > 0) {
+                page++
+            }
+            log.scrollTop = log.scrollHeight
+        }
+    }
+
+    loadMessages()
+
+    log.addEventListener("scroll", () => {
+        if (log.scrollTop + log.clientHeight >= log.scrollHeight - 10) {
+            loadMessages()
+        }
+    })
+
     const scheme = location.protocol === "https:" ? "wss" : "ws"
     const ws = new WebSocket(`${scheme}://${location.host}/streams/${streamId}/ws`)
 


### PR DESCRIPTION
## Summary
- expose a paginated endpoint for messages
- keep messages in memory in a simple store
- pull older pages of messages as the user scrolls in chat view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859abbc4a408331b1decfb106c7cac9