### PR TITLE
Add docker compose services and local dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Streams
+
+## Local Development
+
+This project uses Postgres and Qdrant. A `docker-compose.yml` file is provided to bring up both services.
+
+```bash
+# start the database and vector store
+docker compose up -d
+```
+
+The Postgres service exposes port `5432` and Qdrant listens on `6333`. Stop the stack with `docker compose down` when finished.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: streams
+      POSTGRES_PASSWORD: streams
+      POSTGRES_DB: streams
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    volumes:
+      - qdrant_data:/qdrant/storage
+    ports:
+      - "6333:6333"
+
+volumes:
+  pgdata:
+  qdrant_data:


### PR DESCRIPTION
## Summary
- provide a `docker-compose.yml` for Postgres and Qdrant
- document how to run the stack for development

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859abba38188331890e1f0d86f43a7b