### PR TITLE
Add initial SQL migration for providers, streams and messages

### DIFF
--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,22 @@
+CREATE TABLE providers (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    created TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE streams (
+    id UUID PRIMARY KEY,
+    provider_id UUID NOT NULL REFERENCES providers(id),
+    name TEXT NOT NULL,
+    created TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE messages (
+    id UUID PRIMARY KEY,
+    stream_id UUID NOT NULL REFERENCES streams(id),
+    author TEXT NOT NULL,
+    content TEXT NOT NULL,
+    ts TIMESTAMPTZ NOT NULL DEFAULT now(),
+    epoch_id TEXT
+);
+


### PR DESCRIPTION
## Summary
- initialize database schema
- create SQL migration defining `providers`, `streams`, and `messages`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859abb53fa88331b7db112a9cef17ec