### PR TITLE
Implement stream listing and creation UI

### DIFF
--- a/streams/api/pages.py
+++ b/streams/api/pages.py
@@ -1,6 +1,8 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Request
+
+from streams.storage import postgres
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
@@ -10,8 +12,10 @@ router = APIRouter()
 
 @router.get("/", response_class=HTMLResponse, include_in_schema=False)
 async def index(request: Request):
-    # TODO: query real streams
-    return templates.TemplateResponse("index.html", {"request": request})
+    streams = await postgres.get_streams()
+    return templates.TemplateResponse(
+        "index.html", {"request": request, "streams": streams}
+    )
 
 
 @router.get(

--- a/streams/api/rest.py
+++ b/streams/api/rest.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter
 
+from streams.storage import postgres
+
 router = APIRouter(prefix="/api")
 
 
@@ -11,5 +13,4 @@ async def list_providers():
 
 @router.post("/streams")
 async def create_stream(name: str):
-    # TODO: insert row + return stream info
-    return {"id": "stub", "name": name}
+    return await postgres.create_stream(name)

--- a/streams/storage/postgres.py
+++ b/streams/storage/postgres.py
@@ -1,6 +1,11 @@
 import asyncpg
+from uuid import uuid4
 
 from streams.config import settings
+
+_streams: list[dict] = [
+    {"id": "00000000-0000-0000-0000-000000000001", "name": "demo-stream"}
+]
 
 _pool = None
 
@@ -19,3 +24,15 @@ async def save_message(stream_id, author, content):
         "content": content,
         "epoch_id": None,
     }
+
+
+async def get_streams() -> list[dict]:
+    """Return available streams."""
+    return list(_streams)
+
+
+async def create_stream(name: str) -> dict:
+    """Create a new stream placeholder and return it."""
+    stream = {"id": str(uuid4()), "name": name}
+    _streams.append(stream)
+    return stream

--- a/streams/templates/index.html
+++ b/streams/templates/index.html
@@ -2,16 +2,52 @@
 <div class="flex h-full items-center justify-center">
     <div class="p-8 bg-white rounded-xl shadow-lg w-96">
         <h1 class="text-2xl font-bold mb-6 text-center">Select Stream</h1>
+        <form id="create-form" class="flex gap-2 mb-4">
+            <input
+                id="stream-name"
+                type="text"
+                placeholder="New stream name"
+                class="flex-1 border px-3 py-2 rounded-md"
+            />
+            <button class="px-4 py-2 bg-blue-600 text-white rounded-md">
+                Create
+            </button>
+        </form>
         <ul id="streams" class="space-y-2">
-            <!-- static placeholder -->
+            {% for s in streams %}
             <li>
                 <a
-                    href="/streams/00000000-0000-0000-0000-000000000001"
+                    href="/streams/{{ s.id }}"
                     class="text-blue-600 hover:underline"
-                    >demo-stream</a
+                    >{{ s.name }}</a
                 >
             </li>
+            {% else %}
+            <li class="text-gray-500">No streams.</li>
+            {% endfor %}
         </ul>
     </div>
 </div>
+<script type="module">
+    const form = document.getElementById("create-form")
+    const input = document.getElementById("stream-name")
+    const list = document.getElementById("streams")
+
+    form.addEventListener("submit", async (e) => {
+        e.preventDefault()
+        const name = input.value.trim()
+        if (!name) return
+        const res = await fetch(`/api/streams?name=${encodeURIComponent(name)}`, {
+            method: "POST",
+        })
+        if (res.ok) {
+            const stream = await res.json()
+            list.insertAdjacentHTML(
+                "beforeend",
+                `<li><a class="text-blue-600 hover:underline" href="/streams/${stream.id}">${stream.name}</a></li>`
+            )
+            input.value = ""
+        }
+    })
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- render stream list on the index page
- add form to create streams from the UI
- provide stub `get_streams` and `create_stream` helpers
- wire REST and page handlers to new storage helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859abb269e88331a8f1f3d60e6ad5de