### PR TITLE
Wire up OpenAI embeddings

### DIFF
--- a/streams/config.py
+++ b/streams/config.py
@@ -3,6 +3,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     QDRANT_URL: str = "http://localhost:6333"
+    OPENAI_API_KEY: str | None = None
     EMBED_MODEL: str = "text-embedding-3-small"
     TIME_GAP_MINUTES: int = 30
     SEMANTIC_THRESHOLD: float = 0.30

--- a/streams/services/embeddings.py
+++ b/streams/services/embeddings.py
@@ -1,9 +1,14 @@
-import asyncio
+from openai import AsyncOpenAI
 
 from streams.config import settings
 
 
+client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
+
+
 async def generate(text: str) -> list[float]:
-    # TODO: call your embed API
-    await asyncio.sleep(0)  # simulate async call
-    return [0.0] * 1536
+    resp = await client.embeddings.create(
+        model=settings.EMBED_MODEL,
+        input=text,
+    )
+    return resp.data[0].embedding


### PR DESCRIPTION
## Summary
- add `OPENAI_API_KEY` to settings
- implement OpenAI call in embedding service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859aba47f188331b8f80994f00ab055