### PR TITLE
Implement websocket related link emission

### DIFF
--- a/streams/api/websocket.py
+++ b/streams/api/websocket.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from streams.services.epoch import epoch_manager
+from streams.services import link
 from streams.services.router import StreamRouter
 from streams.storage import postgres
 
@@ -21,6 +22,7 @@ async def chat_ws(ws: WebSocket, stream_id: UUID):
             msg = await postgres.save_message(stream_id, "anon", text)
             await epoch_manager.handle(msg)
             await hub.broadcast({"type": "msg", **msg})
+            await link.emit_related(hub, msg)
     except WebSocketDisconnect:
         pass
     finally:

--- a/streams/services/link.py
+++ b/streams/services/link.py
@@ -1,1 +1,17 @@
-# Placeholder for real-time linker that queries qdrant
+"""Helpers for emitting related conversation links."""
+
+from __future__ import annotations
+
+from streams.services.router import StreamRouter
+
+
+async def emit_related(hub: StreamRouter, msg: dict) -> None:
+    """Broadcast placeholder "related" frame to connected clients.
+
+    This will eventually query Qdrant for semantic neighbours of ``msg`` and
+    include links to those conversations.  For now it simply sends an empty
+    payload so the front-end can react to the event type.
+    """
+
+    await hub.broadcast({"type": "related", "links": []})
+


### PR DESCRIPTION
## Summary
- add helper for sending related conversation frames
- use link service in websocket flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859aba3812883319cb22c8dafb6b6ba