### PR TITLE
Render stream list dynamically

### DIFF
--- a/streams/api/pages.py
+++ b/streams/api/pages.py
@@ -4,14 +4,18 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from streams.storage import postgres
+
 templates = Jinja2Templates(directory="streams/templates")
 router = APIRouter()
 
 
 @router.get("/", response_class=HTMLResponse, include_in_schema=False)
 async def index(request: Request):
-    # TODO: query real streams
-    return templates.TemplateResponse("index.html", {"request": request})
+    streams = await postgres.get_streams()
+    return templates.TemplateResponse(
+        "index.html", {"request": request, "streams": streams}
+    )
 
 
 @router.get(

--- a/streams/storage/postgres.py
+++ b/streams/storage/postgres.py
@@ -19,3 +19,17 @@ async def save_message(stream_id, author, content):
         "content": content,
         "epoch_id": None,
     }
+
+
+async def get_streams():
+    """Return available streams.
+
+    This placeholder implementation yields a single static entry so that the
+    rest of the application can render a stream list without a real database.
+    """
+    return [
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "name": "demo-stream",
+        }
+    ]

--- a/streams/templates/index.html
+++ b/streams/templates/index.html
@@ -3,14 +3,15 @@
     <div class="p-8 bg-white rounded-xl shadow-lg w-96">
         <h1 class="text-2xl font-bold mb-6 text-center">Select Stream</h1>
         <ul id="streams" class="space-y-2">
-            <!-- static placeholder -->
+            {% for stream in streams %}
             <li>
                 <a
-                    href="/streams/00000000-0000-0000-0000-000000000001"
+                    href="/streams/{{ stream.id }}"
                     class="text-blue-600 hover:underline"
-                    >demo-stream</a
+                    >{{ stream.name }}</a
                 >
             </li>
+            {% endfor %}
         </ul>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- query available streams in `pages.index`
- add placeholder `get_streams` to postgres storage
- render dynamic stream links in the index template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859ab9ef04c83318e412b15c328e263