### PR TITLE
Use postgres create_stream in API

### DIFF
--- a/streams/api/rest.py
+++ b/streams/api/rest.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter
 
+from streams.storage import postgres
+
 router = APIRouter(prefix="/api")
 
 
@@ -11,5 +13,4 @@ async def list_providers():
 
 @router.post("/streams")
 async def create_stream(name: str):
-    # TODO: insert row + return stream info
-    return {"id": "stub", "name": name}
+    return await postgres.create_stream(name)


### PR DESCRIPTION
## Summary
- call storage postgres `create_stream` in API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ab9dd9ac8331bdd004abf4f3b71c