### PR TITLE
Implement provider list endpoint

### DIFF
--- a/streams/api/rest.py
+++ b/streams/api/rest.py
@@ -1,12 +1,14 @@
 from fastapi import APIRouter
 
+from streams.storage import postgres
+
 router = APIRouter(prefix="/api")
 
 
 @router.get("/providers")
 async def list_providers():
-    # TODO: fetch from storage
-    return []
+    providers = await postgres.get_providers()
+    return providers
 
 
 @router.post("/streams")

--- a/streams/storage/postgres.py
+++ b/streams/storage/postgres.py
@@ -19,3 +19,10 @@ async def save_message(stream_id, author, content):
         "content": content,
         "epoch_id": None,
     }
+
+
+async def get_providers():
+    if _pool is None:
+        raise RuntimeError("Postgres pool not initialized")
+    rows = await _pool.fetch("SELECT id, name, created FROM providers ORDER BY created")
+    return [dict(r) for r in rows]


### PR DESCRIPTION
## Summary
- add storage accessor import for REST endpoints
- fetch provider list using `postgres.get_providers`
- implement `get_providers` helper in Postgres storage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ab9ca6308331b0bb66a34bd67898